### PR TITLE
added a note about licensing lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@ Want to try writing a lesson? There are two modules which can be used to start y
 - [Workshopper](https://github.com/rvagg/workshopper) (and [how to write a workshopper](http://lin-clark.com/blog/2014/07/01/authoring-nodejs-workshopper-lessons))
 - [Adventure](https://github.com/substack/adventure)
 
+### Licensing
+Both `workshopper` and `adventure` use the permissive MIT/X license so there's no rules about how you license *your* lesson. If you'd like to add a license to your lesson describing how other people can use it but aren't sure which to pick, check out http://choosealicense.com/
+
 Curated by [@linclark](https://github.com/linclark)


### PR DESCRIPTION
Hi @linclark,

There was a [ticket](https://github.com/nodeschool/discussions/issues/253) or [two](https://github.com/nodeschool/discussions/pull/930) on the discussions repo about licensing questions surrounding workshopper & its lessons. Long story short people thought it would be useful to give some guidance to new lesson authors about licensing & "go check out choosealicense.com" seemed to be the most useful and least contentious guidance. :smile:  Lemme know what you think!